### PR TITLE
max PTC password length is 15, save people who uses password managers

### DIFF
--- a/api/pokelocator_api.py
+++ b/api/pokelocator_api.py
@@ -263,7 +263,7 @@ def login_ptc(username, password):
         'execution': jdata['execution'],
         '_eventId': 'submit',
         'username': username,
-        'password': password,
+        'password': password[0:15],
     }
     r1 = SESSION.post(LOGIN_URL, data=data, headers=head)
 


### PR DESCRIPTION
I wasted about 2 hours trying to get this to work, not realizing the PTC signed me up with truncated version (15 chars) of my generated password (50 chars).  Maybe this will save someone else the pain later.
